### PR TITLE
[M2-001] Update Main Screen

### DIFF
--- a/app/src/main/java/id/dev/qrcraft/MainActivity.kt
+++ b/app/src/main/java/id/dev/qrcraft/MainActivity.kt
@@ -4,10 +4,17 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.graphics.Color
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import id.dev.core.presentation.theme.QRCraftTheme
+import id.dev.qrcraft.navigation.components.BottomNavBar
 import id.dev.qrcraft.navigation.navs.AppNavigation
+import id.dev.qrcraft.navigation.screens.Screens
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -17,7 +24,43 @@ class MainActivity : ComponentActivity() {
         setContent {
             QRCraftTheme {
                 val navController = rememberNavController()
-                AppNavigation(navController = navController)
+
+                val navBackStackEntry by navController.currentBackStackEntryAsState()
+                val currentRoute = navBackStackEntry?.destination?.route
+
+                Scaffold(
+                    containerColor = Color.Transparent,
+                    contentWindowInsets = WindowInsets(0, 0, 0, 0),
+                    bottomBar = {
+                        BottomNavBar(
+                            selectedRoute = currentRoute ?: Screens.CameraScreen.toString(),
+                            onHistoryClick = { /* Handle history click */ },
+                            onScanClick = {
+                                navController.navigate(Screens.CameraScreen) {
+                                    launchSingleTop = true
+                                    restoreState = true
+                                    popUpTo(Screens.CameraScreen) {
+                                        saveState = true
+                                    }
+                                }
+                            },
+                            onPlusClick = {
+                                navController.navigate(Screens.CreateQrScreen) {
+                                    launchSingleTop = true
+                                    restoreState = true
+                                    popUpTo(Screens.CameraScreen) {
+                                        saveState = true
+                                    }
+                                }
+                            }
+                        )
+                    }
+                ) {
+                    AppNavigation(
+                        navController = navController,
+                        contentPadding = it
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/id/dev/qrcraft/navigation/components/BottomNavBar.kt
+++ b/app/src/main/java/id/dev/qrcraft/navigation/components/BottomNavBar.kt
@@ -1,0 +1,173 @@
+package id.dev.qrcraft.navigation.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.FloatingActionButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import id.dev.core.presentation.R
+import id.dev.core.presentation.theme.QRCraftTheme
+import id.dev.core.presentation.theme.link
+import id.dev.core.presentation.utils.DeviceConfiguration
+import id.dev.core.presentation.utils.applyIf
+import id.dev.qrcraft.navigation.screens.Screens
+
+@Composable
+fun BottomNavBar(
+    selectedRoute: String,
+    onHistoryClick: () -> Unit,
+    onScanClick: () -> Unit,
+    onPlusClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val qRScreenActive = selectedRoute.contains(Screens.CreateQrScreen.toString())
+    val historyScreenActive = selectedRoute.contains(Screens.HistoryQrScreen.toString())
+
+    val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
+    val deviceConfiguration = DeviceConfiguration.fromWindowSizeClass(windowSizeClass)
+
+    val fabSize = when (deviceConfiguration) {
+        DeviceConfiguration.MOBILE_PORTRAIT, DeviceConfiguration.MOBILE_LANDSCAPE -> 64.dp
+        else -> 72.dp
+    }
+
+    val fabIconSize = when (deviceConfiguration) {
+        DeviceConfiguration.MOBILE_PORTRAIT, DeviceConfiguration.MOBILE_LANDSCAPE -> 22.dp
+        else -> 32.dp
+    }
+
+    val iconSize = when (deviceConfiguration) {
+        DeviceConfiguration.MOBILE_PORTRAIT, DeviceConfiguration.MOBILE_LANDSCAPE -> 16.dp
+        else -> 24.dp
+    }
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .navigationBarsPadding()
+            .padding(bottom = 16.dp),
+        contentAlignment = Alignment.BottomCenter
+    ) {
+        Surface(
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+            shape = RoundedCornerShape(100),
+            modifier = Modifier
+                .sizeIn(maxWidth = 180.dp, maxHeight = 55.dp)
+        ) {
+            Row(
+                modifier = Modifier
+                    .padding(horizontal = 6.dp, vertical = 2.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(44.dp)
+                        .applyIf(historyScreenActive) {
+                            background(
+                                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.3f),
+                                shape = CircleShape
+                            )
+                        }
+                        .clickable(
+                            interactionSource = null,
+                            indication = null
+                        ) {
+                            onHistoryClick()
+                        },
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = ImageVector.vectorResource(R.drawable.clock_refresh),
+                        contentDescription = null,
+                        modifier = Modifier.size(iconSize),
+                        tint = if (historyScreenActive) link else MaterialTheme.colorScheme.onSurface
+                    )
+                }
+
+                Spacer(Modifier.weight(1f))
+
+                Box(
+                    modifier = Modifier
+                        .size(44.dp)
+                        .applyIf(qRScreenActive) {
+                            background(
+                                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.5f),
+                                shape = CircleShape
+                            )
+                        }
+                        .clickable(
+                            interactionSource = null,
+                            indication = null
+                        ) {
+                            onPlusClick()
+                        },
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = ImageVector.vectorResource(R.drawable.plus_circle),
+                        contentDescription = null,
+                        modifier = Modifier.size(iconSize),
+                        tint = if (qRScreenActive) link else MaterialTheme.colorScheme.onSurface
+                    )
+                }
+            }
+        }
+
+        FloatingActionButton(
+            onClick = onScanClick,
+            containerColor = MaterialTheme.colorScheme.primary,
+            contentColor = MaterialTheme.colorScheme.onSurface,
+            elevation = FloatingActionButtonDefaults.elevation(defaultElevation = 8.dp),
+            shape = CircleShape,
+            modifier = Modifier
+                .size(fabSize)
+                .offset(y = 4.dp)
+        ) {
+            Icon(
+                imageVector = ImageVector.vectorResource(R.drawable.scan),
+                contentDescription = null,
+                modifier = Modifier.size(fabIconSize)
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFFF3F3F3)
+@Composable
+private fun BottomNavBarPreview() {
+    QRCraftTheme {
+        Box(Modifier.fillMaxSize()) {
+            BottomNavBar(
+                selectedRoute = Screens.CreateQrScreen.toString(),
+                modifier = Modifier.align(Alignment.BottomCenter),
+                onHistoryClick = {},
+                onScanClick = {},
+                onPlusClick = {}
+            )
+        }
+    }
+}

--- a/app/src/main/java/id/dev/qrcraft/navigation/navs/AppNavigation.kt
+++ b/app/src/main/java/id/dev/qrcraft/navigation/navs/AppNavigation.kt
@@ -1,10 +1,14 @@
 package id.dev.qrcraft.navigation.navs
 
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import id.dev.home.presentation.camera.CameraScreenRoot
+import id.dev.home.presentation.create_qr.CreateQRRoot
 import id.dev.home.presentation.model.BarcodeResult
 import id.dev.home.presentation.scanResult.ScanResultScreenRoot
 import id.dev.qrcraft.navigation.screens.Screens
@@ -12,15 +16,17 @@ import kotlinx.serialization.json.Json
 
 @Composable
 fun AppNavigation(
-    navController: NavHostController
+    navController: NavHostController,
+    contentPadding: PaddingValues
 ) {
     NavHost(
         navController = navController,
-        startDestination = Screens.CameraScreen
+        startDestination = Screens.CameraScreen,
+        modifier = Modifier.consumeWindowInsets(contentPadding)
     ) {
         composable<Screens.CameraScreen> {
             CameraScreenRoot(
-                onScanResult = { barcodeResult, ->
+                onScanResult = { barcodeResult ->
                     if (barcodeResult !is BarcodeResult.ScanError) {
                         val result = Json.encodeToString(BarcodeResult.serializer(), barcodeResult)
                         navController.navigate(
@@ -29,7 +35,7 @@ fun AppNavigation(
                             )
                         )
                     }
-                }
+                },
             )
         }
         composable<Screens.ScanResultScreen> {
@@ -38,6 +44,9 @@ fun AppNavigation(
                     navController.navigateUp()
                 },
             )
+        }
+        composable<Screens.CreateQrScreen> {
+            CreateQRRoot()
         }
     }
 }

--- a/app/src/main/java/id/dev/qrcraft/navigation/screens/Screens.kt
+++ b/app/src/main/java/id/dev/qrcraft/navigation/screens/Screens.kt
@@ -12,4 +12,10 @@ sealed interface Screens {
     data class ScanResultScreen(
         val barcodeResult: String
     )
+
+    @Serializable
+    data object CreateQrScreen
+
+    @Serializable
+    data object HistoryQrScreen
 }

--- a/core/presentation/src/main/java/id/dev/core/presentation/utils/Extension.kt
+++ b/core/presentation/src/main/java/id/dev/core/presentation/utils/Extension.kt
@@ -1,0 +1,13 @@
+package id.dev.core.presentation.utils
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun Modifier.applyIf(condition: Boolean, modifier: @Composable Modifier.() -> Modifier): Modifier {
+    return if (condition) {
+        then(modifier())
+    } else {
+        this
+    }
+}

--- a/home/presentation/src/main/java/id/dev/home/presentation/camera/CameraScreen.kt
+++ b/home/presentation/src/main/java/id/dev/home/presentation/camera/CameraScreen.kt
@@ -93,7 +93,7 @@ fun CameraScreen(
     var cutoutOffset by remember { mutableStateOf(Offset.Zero) }
     var cutoutSizePx by remember { mutableStateOf(IntSize.Zero) }
 
-    val boundingBox: Rect? = remember(cutoutSizePx, cutoutSizePx) {
+    val scanRect: Rect? = remember(cutoutOffset, cutoutSizePx) {
         if (cutoutSizePx.width > 0 && cutoutSizePx.height > 0) {
             Rect(
                 cutoutOffset.x,
@@ -101,9 +101,7 @@ fun CameraScreen(
                 cutoutOffset.x + cutoutSizePx.width,
                 cutoutOffset.y + cutoutSizePx.height
             )
-        } else {
-            null
-        }
+        } else null
     }
 
     val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
@@ -170,16 +168,17 @@ fun CameraScreen(
                     onQrCodeScanned = { result ->
                         onAction(CameraScreenAction.OnScanResult(result))
                     },
-                    boundingBox = boundingBox
+                    boundingBox = scanRect
                 )
             }
 
             CameraOverlayWithCutout(
                 hasCameraPermission = state.hasCameraPermission,
-                cutoutOffsetState = cutoutOffset,
-                cutoutSizeState = cutoutSizePx,
+                scanRect = scanRect,
                 cutoutSize = when (deviceConfiguration) {
-                    DeviceConfiguration.MOBILE_PORTRAIT, DeviceConfiguration.MOBILE_LANDSCAPE -> 300.dp
+                    DeviceConfiguration.MOBILE_PORTRAIT-> 300.dp
+                    DeviceConfiguration.MOBILE_LANDSCAPE -> 200.dp
+                    DeviceConfiguration.TABLET_LANDSCAPE -> 400.dp
                     else -> 500.dp
                 },
                 cutoutShape = when (deviceConfiguration) {

--- a/home/presentation/src/main/java/id/dev/home/presentation/create_qr/CreateQRAction.kt
+++ b/home/presentation/src/main/java/id/dev/home/presentation/create_qr/CreateQRAction.kt
@@ -1,0 +1,5 @@
+package id.dev.home.presentation.create_qr
+
+sealed interface CreateQRAction {
+
+}

--- a/home/presentation/src/main/java/id/dev/home/presentation/create_qr/CreateQREvent.kt
+++ b/home/presentation/src/main/java/id/dev/home/presentation/create_qr/CreateQREvent.kt
@@ -1,0 +1,5 @@
+package id.dev.home.presentation.create_qr
+
+sealed interface CreateQREvent {
+
+}

--- a/home/presentation/src/main/java/id/dev/home/presentation/create_qr/CreateQRScreen.kt
+++ b/home/presentation/src/main/java/id/dev/home/presentation/create_qr/CreateQRScreen.kt
@@ -1,0 +1,55 @@
+
+package id.dev.home.presentation.create_qr
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import id.dev.core.presentation.theme.QRCraftTheme
+import id.dev.core.presentation.utils.ObserveAsEvents
+import org.koin.androidx.compose.koinViewModel
+
+@Composable
+fun CreateQRRoot(
+    viewModel: CreateQRViewModel = koinViewModel()
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    ObserveAsEvents(viewModel.event) { event ->
+
+    }
+
+    CreateQRScreen(
+        state = state,
+        onAction = viewModel::onAction
+    )
+}
+
+@Composable
+fun CreateQRScreen(
+    state: CreateQRState,
+    onAction: (CreateQRAction) -> Unit,
+) {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text("Create QR")
+    }
+}
+
+@Preview
+@Composable
+private fun Preview() {
+    QRCraftTheme {
+        CreateQRScreen(
+            state = CreateQRState(),
+            onAction = {}
+        )
+    }
+}

--- a/home/presentation/src/main/java/id/dev/home/presentation/create_qr/CreateQRState.kt
+++ b/home/presentation/src/main/java/id/dev/home/presentation/create_qr/CreateQRState.kt
@@ -1,0 +1,6 @@
+package id.dev.home.presentation.create_qr
+
+data class CreateQRState(
+    val paramOne: String = "default",
+    val paramTwo: List<String> = emptyList(),
+)

--- a/home/presentation/src/main/java/id/dev/home/presentation/create_qr/CreateQRViewModel.kt
+++ b/home/presentation/src/main/java/id/dev/home/presentation/create_qr/CreateQRViewModel.kt
@@ -1,0 +1,38 @@
+package id.dev.home.presentation.create_qr
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.receiveAsFlow
+
+class CreateQRViewModel : ViewModel() {
+
+    private var hasLoadedInitialData = false
+
+    private val _state = MutableStateFlow(CreateQRState())
+    val state = _state
+        .onStart {
+            if (!hasLoadedInitialData) {
+                /** Load initial data here **/
+                hasLoadedInitialData = true
+            }
+        }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000L),
+            initialValue = CreateQRState()
+        )
+
+    private val _event = Channel<CreateQREvent>()
+    val event = _event.receiveAsFlow()
+
+    fun onAction(action: CreateQRAction) {
+        when (action) {
+            else -> TODO("Handle actions")
+        }
+    }
+}

--- a/home/presentation/src/main/java/id/dev/home/presentation/di/HomePresentationModule.kt
+++ b/home/presentation/src/main/java/id/dev/home/presentation/di/HomePresentationModule.kt
@@ -1,6 +1,7 @@
 package id.dev.home.presentation.di
 
 import id.dev.home.presentation.camera.CameraScreenViewModel
+import id.dev.home.presentation.create_qr.CreateQRViewModel
 import id.dev.home.presentation.scanResult.ScanResultScreenViewModel
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
@@ -8,4 +9,5 @@ import org.koin.dsl.module
 val homePresentationModule = module {
     viewModelOf(::CameraScreenViewModel)
     viewModelOf(::ScanResultScreenViewModel)
+    viewModelOf(::CreateQRViewModel)
 }

--- a/home/presentation/src/main/java/id/dev/home/presentation/scanResult/ScanResultScreen.kt
+++ b/home/presentation/src/main/java/id/dev/home/presentation/scanResult/ScanResultScreen.kt
@@ -51,7 +51,8 @@ import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
 fun ScanResultScreenRoot(
-    onNavigateUp: () -> Unit = {}, viewModel: ScanResultScreenViewModel = koinViewModel()
+    onNavigateUp: () -> Unit = {},
+    viewModel: ScanResultScreenViewModel = koinViewModel()
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
 
@@ -62,7 +63,8 @@ fun ScanResultScreenRoot(
             }
 
             viewModel.onAction(action)
-        })
+        }
+    )
 }
 
 @Composable

--- a/home/presentation/src/main/java/id/dev/home/presentation/scanResult/components/QrCodeImageLayout.kt
+++ b/home/presentation/src/main/java/id/dev/home/presentation/scanResult/components/QrCodeImageLayout.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color


### PR DESCRIPTION
feat: Prepare Create QR screen and Implement bottom navigation bar

This commit introduces the following changes:

- Added `CreateQRScreen`, `CreateQRViewModel`, `CreateQRState`, `CreateQRAction`, and `CreateQREvent` for the new Create QR feature.
- Implemented `BottomNavBar` composable for app navigation, including History, Scan, and Create QR actions.
- Integrated `BottomNavBar` into `MainActivity` using `Scaffold`.
- Updated `AppNavigation` to include the `CreateQrScreen` destination and handle content padding.
- Refactored `CameraOverlayWithCutout` to use `scanRect` for positioning and adjusted layout for different device configurations.
- Added `applyIf` extension function in `core/presentation`.
- Added `CreateQRViewModel` to `homePresentationModule`.
- Defined `CreateQrScreen` and `HistoryQrScreen` in `Screens.kt`.